### PR TITLE
Update phrases.json

### DIFF
--- a/client/src/data/phrases.json
+++ b/client/src/data/phrases.json
@@ -276,7 +276,7 @@
       "en": "Futures",
       "ct": "meow",
       "ne": "Futures",
-      "lt": "Ateities taškai",
+      "lt": "Futuristinė galia",
       "hu": "Jövendők"
     },
 
@@ -284,7 +284,7 @@
       "en": "Show Futures",
       "ct": "meow",
       "ne": "Laat Futures zien",
-      "lt": "Rodyti ateities sugebėjimus",
+      "lt": "Futuristiniai sugebėjimai",
       "hu": "Jövendők Mutatása"
     },
 
@@ -591,7 +591,7 @@
 
     "futures": {
       "en": "futures",
-      "lt": "Ateities Taškai",
+      "lt": "Futuristinė galia",
       "ct": "meow",
       "sv": "framtid",
       "fr": "Futurs",
@@ -817,7 +817,7 @@
     "futures": {
       "en": "Futures",
       "ct": "meow",
-      "lt": "Ateitys",
+      "lt": "Futuristiniai sugebėjimai",
       "fr": "Futurs",
       "sv": "Framitid",
       "pi": "Days after tomorrow",


### PR DESCRIPTION
Updated "futures" strings, to make more sense. For example my translation of "showFutures" was  referring to "Inspect/See future places/events" rather than "Show future abilities"(as it's now).
